### PR TITLE
Fix a typo

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
       A GitHub token to make requests to the API with. Requires write
       permissions to: create new branches, make commits, and open Pull Requests.
       Defaults to `token` from the GitHub context, which is functionally
-      equivalent to `${{ secrets.GITHUB_TOKEN }}`.
+      equivalent to `secrets.GITHUB_TOKEN`.
     required: false
     default: ${{ github.token }}
   repository:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

Due to the `${{ ... }}` syntax, the GitHub Actions runner was trying to import a secret at build time in the action.yaml file. The caused an error.